### PR TITLE
Add express-validator and body-parser to docs and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ var schemas = require('some/schema/definitions');
 var express = require('express');
 var expressValidator = require('express-validator');
 var bodyParser = require('body-parser');
+
 var app = express();
 var Router = express.Router;
 var router = new Router();
@@ -31,31 +32,33 @@ router.use(expressValidator({
 
 router.use(bodyParser.json());
 
-router.route('/resource/:id')
-.spec({
-  get: {
-    summary: 'A resource',
-    parameters: [{
-      name: 'id',
-      description: 'An id',
-      in: 'path',
-      type: 'string',
+router
+  .route('/resource/:id')
+  .spec({
+    get: {
+      summary: 'A resource',
+      parameters: [{
+        name: 'id',
+        description: 'An id',
+        in: 'path',
+        type: 'string',
+        // ...
+      }],
+      resources: {
+        200: {}
+      }
+    },
+    post: {
       // ...
-    }],
-    resources: {
-      200: {}
     }
-  },
-  post: {
-    // ...
-  }
-})
-.validate()
-.get(function (req, res) {
-  res.send({ such: 'data' });
-});
+  })
+  .validate()
+  .get(function (req, res) {
+    res.send({ such: 'data' });
+  });
 
 app.use(router);
+
 docs
   .addInfo(/* swagger info */)
   .addDefinitions(schemas)
@@ -65,7 +68,7 @@ app.get('/swagger.json', function (req, res) {
   res.json(docs.generateDoc());
 });
 
-// app.listen and stuff
+app.listen(3000);
 ```
 
 This will render a swagger file at /swagger.json.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,17 @@ var Swagger = require('swagger-2.0-node-express-4.x');
 var docs = new Swagger();
 var schemas = require('some/schema/definitions');
 var express = require('express');
+var expressValidator = require('express-validator');
+var bodyParser = require('body-parser');
 var app = express();
 var Router = express.Router;
 var router = new Router();
+
+router.use(expressValidator({
+  customValidators: Swagger.customValidators
+}));
+
+router.use(bodyParser.json());
 
 router.route('/resource/:id')
 .spec({

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   ],
   "license": "ISC",
   "peerDependencies": {
-    "express": "^4.9.7"
+    "express": "^4.9.7",
+    "express-validator": "^2.6.0",
+    "body-parser": "^1.16.0"
   }
 }


### PR DESCRIPTION
You'll get some pretty arcane errors if you don't happen to have `express-validator` and `body-parser` in your application dependencies (like `TypeError: checker is not a function`). This pull request will warn you on `npm install` if you don't, and make sure you remember to configure them.

Ideally I'd like to initialize these middlewares behind the scenes, but I'm not sure that it's possible to do in a nice way (and even if it is it'd make it a lot harder to change their options).