### PR TITLE
Add support for request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ var schemas = require('some/schema/definitions');
 var express = require('express');
 var expressValidator = require('express-validator');
 var bodyParser = require('body-parser');
+
 var app = express();
 var Router = express.Router;
 var router = new Router();
@@ -31,31 +32,33 @@ router.use(expressValidator({
 
 router.use(bodyParser.json());
 
-router.route('/resource/:id')
-.spec({
-  get: {
-    summary: 'A resource',
-    parameters: [{
-      name: 'id',
-      description: 'An id',
-      in: 'path',
-      type: 'string',
+router
+  .route('/resource/:id')
+  .spec({
+    get: {
+      summary: 'A resource',
+      parameters: [{
+        name: 'id',
+        description: 'An id',
+        in: 'path',
+        type: 'string',
+        // ...
+      }],
+      resources: {
+        200: {}
+      }
+    },
+    post: {
       // ...
-    }],
-    resources: {
-      200: {}
     }
-  },
-  post: {
-    // ...
-  }
-})
-.validate()
-.get(function (req, res) {
-  res.send({ such: 'data' });
-});
+  })
+  .validate()
+  .get(function (req, res) {
+    res.send({ such: 'data' });
+  });
 
 app.use(router);
+
 docs
   .addInfo(/* swagger info */)
   .addDefinitions(schemas)
@@ -65,7 +68,7 @@ app.get('/swagger.json', function (req, res) {
   res.json(docs.generateDoc());
 });
 
-// app.listen and stuff
+app.listen(3000);
 ```
 
 This will render a swagger file at /swagger.json.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,17 @@ var Swagger = require('swagger-2.0-node-express-4.x');
 var docs = new Swagger();
 var schemas = require('some/schema/definitions');
 var express = require('express');
+var expressValidator = require('express-validator');
+var bodyParser = require('body-parser');
 var app = express();
 var Router = express.Router;
 var router = new Router();
+
+router.use(expressValidator({
+  customValidators: Swagger.customValidators
+}));
+
+router.use(bodyParser.json());
 
 router.route('/resource/:id')
 .spec({

--- a/lib/route.js
+++ b/lib/route.js
@@ -102,29 +102,51 @@ function validate (req, param) {
     return;
   }
 
-  if(param.required) {
-    checker([param.name], param.name + ' is required').isSet();
+  // Run all checkers on the given parameter.
+  //
+  // name - A string describing the name of the parameter.
+  // options - An object describing swagger options (type, format, pattern etc.)
+  var checkers = function (name, options) {
+    if(options.type && validatorsByType[options.type]) {
+      checker([name], name + ' must be of type ' + options.type)[validatorsByType[options.type]]();
+    }
+    if(options.format && req[validatorsByFormat[options.format]]) {
+      checker([name], name + ' must have format ' + options.type)[validatorsByFormat[options.format]]();
+    }
+    if(options.pattern) {
+      checker([name], name + ' must match pattern ' + options.pattern).matches(options.pattern);
+    }
+    if('minLength' in options) {
+      checker([name], name + ' must be at least ' + options.minLength + ' characters long').isLength(options.minLength);
+    }
+    if('maxLength' in options) {
+      checker([name], name + ' must be no more than ' + options.maxLength + ' characters long').isLength(0, options.maxLength);
+    }
+    if('minimum' in options) {
+      checker([name], name + ' must be at least ' + options.minimum).isGreaterThan(options.minimum - (options.exclusiveMinimum ? 0 : 1));
+    }
+    if('maximum' in options) {
+      checker([name], name + ' must be at most ' + options.maximum).isLessThan(options.minimum + (options.exclusiveMaximum ? 0 : 1));
+    }
   }
-  if(param.type && validatorsByType[param.type]) {
-    checker([param.name], param.name + ' must be of type ' + param.type)[validatorsByType[param.type]]();
-  }
-  if(param.format && req[validatorsByFormat[param.format]]) {
-    checker([param.name], param.name + ' must have format ' + param.type)[validatorsByFormat[param.format]]();
-  }
-  if(param.pattern) {
-    checker([param.name], param.name + ' must match pattern ' + param.pattern).matches(param.pattern);
-  }
-  if('minLength' in param) {
-    checker([param.name], param.name + ' must be at least ' + param.minLength + ' characters long').isLength(param.minLength);
-  }
-  if('maxLength' in param) {
-    checker([param.name], param.name + ' must be no more than ' + param.maxLength + ' characters long').isLength(0, param.maxLength);
-  }
-  if('minimum' in param) {
-    checker([param.name], param.name + ' must be at least ' + param.minimum).isGreaterThan(param.minimum - (param.exclusiveMinimum ? 0 : 1));
-  }
-  if('maximum' in param) {
-    checker([param.name], param.name + ' must be at most ' + param.maximum).isLessThan(param.minimum + (param.exclusiveMaximum ? 0 : 1));
+
+  if(param.in == 'body') {
+    if(param.required) {
+      param.schema.required.forEach(function (property) {
+        checker([property], property + ' is required in request body').isSet();
+      });
+    }
+
+    Object.keys(param.schema.properties).forEach(function (property) {
+      var options = param.schema.properties[property];
+      checkers(property, options);
+    });
+  } else {
+    if(param.required) {
+      checker([param.name], param.name + ' is required').isSet();
+    }
+
+    checkers(param.name, param);
   }
 }
 
@@ -231,3 +253,5 @@ function setValidationErrorResponse (spec) {
     }
   });
 }
+
+module.exports.validate = validate;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "repository": "https://github.com/omninews/swagger-2.0-node-express-4.x.git",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "keywords": [
     "swagger",
@@ -21,6 +21,14 @@
   "license": "ISC",
   "peerDependencies": {
     "express": "^4.9.7",
+    "express-validator": "^2.6.0",
+    "body-parser": "^1.16.0"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "chai-http": "^3.0.0",
+    "express": "^4.9.7",
+    "mocha": "^3.2.0",
     "express-validator": "^2.6.0",
     "body-parser": "^1.16.0"
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   ],
   "license": "ISC",
   "peerDependencies": {
-    "express": "^4.9.7"
+    "express": "^4.9.7",
+    "express-validator": "^2.6.0",
+    "body-parser": "^1.16.0"
   }
 }

--- a/test/app.js
+++ b/test/app.js
@@ -1,0 +1,61 @@
+var swagger = require('../lib');
+var express = require('express');
+var expressValidator = require('express-validator');
+var bodyParser = require('body-parser');
+
+var app = express();
+
+app.use(expressValidator({
+  customValidators: swagger.customValidators
+}));
+
+app.use(bodyParser.json());
+
+var success = function (req, res) {
+  res.sendStatus(200);
+};
+
+app
+  .route('/query-required')
+  .spec({
+    get: {
+      parameters: [
+        {
+          name: 'foo',
+          in: 'query',
+          required: true
+        }
+      ]
+    }
+  })
+  .validate()
+  .get(success);
+
+app
+  .route('/body-required')
+  .spec({
+    post: {
+      parameters: [
+        {
+          name: 'body',
+          in: 'body',
+          required: true,
+          schema: {
+            required: ['string', 'integer'],
+            properties: {
+              string: {
+                type: 'string',
+              },
+              integer: {
+                type: 'integer',
+              }
+            }
+          }
+        }
+      ]
+    }
+  })
+  .validate()
+  .post(success);
+
+module.exports = app;

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+var assert = require('assert');
+var chai = require('chai');
+var chaiHttp = require('chai-http');
+var app = require('./app');
+
+var expect = chai.expect;
+
+chai.use(chaiHttp);
+
+describe('validate', function () {
+  describe('body', function () {
+    context('with right body', function () {
+      it('returns HTTP 200', function (done) {
+        chai
+          .request(app)
+          .post('/body-required')
+          .send({ string: 'string', integer: '123' })
+          .end(function (err, res) {
+            expect(res).to.have.status(200);
+            done();
+          });
+      });
+    });
+
+    context('with wrong body', function () {
+      it('returns HTTP 400', function (done) {
+        chai
+          .request(app)
+          .post('/body-required')
+          .send({ integer: 'foo' })
+          .end(function (err, res) {
+            expect(res).to.have.status(400);
+            expect(res.body).to.deep.equal([
+              { param: 'string', msg: 'string is required in request body' },
+              { param: 'integer', msg: 'integer must be of type integer', value: 'foo'},
+            ]);
+            done();
+          });
+      });
+    });
+
+    context('without body', function () {
+      it('returns HTTP 400', function (done) {
+        chai
+          .request(app)
+          .post('/body-required')
+          .end(function (err, res) {
+            expect(res).to.have.status(400);
+            done();
+          });
+      });
+    });
+  });
+
+  describe('query parameters', function () {
+    context('with query parameters', function () {
+      it('returns HTTP 200', function (done) {
+        chai
+          .request(app)
+          .get('/query-required?foo=bar')
+          .end(function (err, res) {
+            expect(res).to.have.status(200);
+            done();
+          });
+      });
+    });
+
+    context('without query parameters', function() {
+      it('returns HTTP 400', function (done) {
+        chai
+          .request(app)
+          .get('/query-required')
+          .end(function (err, res) {
+            expect(res).to.have.status(400);
+            done();
+          });
+      });
+    });
+  });
+});


### PR DESCRIPTION
_This pull request builds upon #2, so merge that first._

Previously, specifying that a request had a body would actually validate that the body had a property _called_ `body`. For example:

    paths:
      /:
        post:
          parameters:
            - name: body
              in: body
              required: true
              schema:
                required:
                  - foo
                  - bar
                properties:
                  foo:
                    type: string
                  bar:
                    type: string

    # This is what we specified, but it doesn't validate
    POST / HTTP/1.1
    Content-Type: application/json; charset=utf-8

    { "foo": "foo", "bar": "bar" }

    HTTP/1.1 400 Bad Request
    Content-Type: application/json; charset=utf-8

    [
      {
        "param": "body",
        "msg": "body is required"
      }
    ]

    # This isn't what we specified, but it validates
    POST / HTTP/1.1
    Content-Type: application/json; charset=utf-8

    { "body": { "foo": "foo", "bar": "bar" } }

    HTTP/1.1 200 OK

:sparkles: Conveniently, this also adds support for validating the format, length, pattern etc. of properties in the request body. :sparkles:

```
$ npm run test
> validate
    body
      with right body
        ✓ returns HTTP 200 (41ms)
      with wrong body
        ✓ returns HTTP 400
      without body
        ✓ returns HTTP 400
    query parameters
      with query parameters
        ✓ returns HTTP 200
      without query parameters
        ✓ returns HTTP 400


> 5 passing (62ms)
```